### PR TITLE
Fragen überspringen, wenn kein traumatisches Ereignis vorliegt

### DIFF
--- a/Examples/Questionnaire.json
+++ b/Examples/Questionnaire.json
@@ -1706,12 +1706,6 @@
               "text": "Nr.",
               "type": "integer",
               "required": true 
-            },
-            {
-              "linkId": "LifeEventsChecklist.MostStressfulEventDetails",
-              "text": "Beschreiben Sie kurz dieses belastende Ereignis in Stichworten",
-              "type": "string",
-              "required": true
             }
           ]
         }

--- a/Examples/Questionnaire.json
+++ b/Examples/Questionnaire.json
@@ -1715,8 +1715,71 @@
       "linkId": "LifeEventsChecklist.MostStressfulEventPeriod",
       "text": "Wann ist dieses belastende Ereignis passiert?",
       "type": "choice",
-      "required": false,
+      "required": true,
       "repeats": false,
+      "enableBehavior": "any",
+      "enableWhen": [
+        {
+          "question": "LifeEventsChecklist.AccidentFireExplosion",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.NaturalDisaster",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.PhysicalAssaultFamilyFriends",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.PhysicalAssaultForeignPerson",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.SexualAssaultFamilyFriends",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.SexualAssaultForeignPerson",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.CombatExposureWarZone",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.SexualAbuseUnderage",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.Captivity",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.SevereHumanSuffering",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.LifeThreateningIllnessInjury",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.OtherTraumaticEvent",
+          "operator": "=",
+          "answerBoolean": true
+        }
+      ],
       "answerOption": [
         {
           "valueString": "vor weniger als 1 Monat"

--- a/Examples/Questionnaire.json
+++ b/Examples/Questionnaire.json
@@ -1832,6 +1832,69 @@
       "type": "group",
       "required": true,
       "repeats": false,
+      "enableBehavior": "any",
+      "enableWhen": [
+        {
+          "question": "LifeEventsChecklist.AccidentFireExplosion",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.NaturalDisaster",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.PhysicalAssaultFamilyFriends",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.PhysicalAssaultForeignPerson",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.SexualAssaultFamilyFriends",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.SexualAssaultForeignPerson",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.CombatExposureWarZone",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.SexualAbuseUnderage",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.Captivity",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.SevereHumanSuffering",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.LifeThreateningIllnessInjury",
+          "operator": "=",
+          "answerBoolean": true
+        },
+        {
+          "question": "LifeEventsChecklist.OtherTraumaticEvent",
+          "operator": "=",
+          "answerBoolean": true
+        }
+      ],
       "item": [
         {
           "linkId": "PC-PTSD-5.1",

--- a/Examples/Questionnaire.json
+++ b/Examples/Questionnaire.json
@@ -1705,7 +1705,7 @@
               "linkId": "LifeEventsChecklist.MostStressfullEventNumber",
               "text": "Nr.",
               "type": "integer",
-              "required": true 
+              "required": false
             }
           ]
         }

--- a/Examples/QuestionnaireResponse_Musterfrau-contained.json
+++ b/Examples/QuestionnaireResponse_Musterfrau-contained.json
@@ -626,15 +626,6 @@
                   "valueInteger": 6
                 }
               ]
-            },
-            {
-              "linkId": "LifeEventsChecklist.MostStressfulEventDetails",
-              "text": "Beschreiben Sie kurz dieses belastende Ereignis in Stichworten",
-              "answer": [
-                {
-                  "valueString": "Beim Spielen im Wald von Fremden angegriffen; sex. Mißbrauch"
-                }
-              ]
             }
           ]
         }

--- a/Examples/QuestionnaireResponse_Musterfrau.json
+++ b/Examples/QuestionnaireResponse_Musterfrau.json
@@ -625,15 +625,6 @@
                   "valueInteger": 6
                 }
               ]
-            },
-            {
-              "linkId": "LifeEventsChecklist.MostStressfulEventDetails",
-              "text": "Beschreiben Sie kurz dieses belastende Ereignis in Stichworten",
-              "answer": [
-                {
-                  "valueString": "Beim Spielen im Wald von Fremden angegriffen; sex. Mißbrauch"
-                }
-              ]
             }
           ]
         }


### PR DESCRIPTION
In Absprache mit Frau Schellong hätten wir folgende Änderungswünsche an die Spezifikation:

* Die Frage nach der Beschreibung des belastenden Ereignisses (item `LifeEventsChecklist.MostStressfulEventDetails`) führte dazu, dass Patienten unnötig an das Ereignis erinnert werden. Manchmal sogar so, dass die Patienten nicht mehr in der Lage sind, den Fragebogen weiter auszufüllen. Die Frage ist in der Papierversion noch drin, wird aber zeitnah entfernt. In der DgApp wird sie auch nicht gestellt. 
* Die Frage, wann das belastende Ereignis passiert sei (item `LifeEventsChecklist.MostStressfulEventPeriod`), sollte übersprungen werden, wenn der Patient keins angekreuzt hat. Dazu habe ich für jede `LifeEventsChecklist.*` ein `enableWhen` eingefügt. Gleichzeitig kann die Beantwortung nun verpflichtend sein.
* Der PC-PTSD-5 sollte dann ebenfalls übersprungen werden. In den Fragen stehen Bezüge auf "das/die Ereignis(se)", die ohne ein angekreuztes Ereignis keinen Sinn ergeben.
* Die Frage nach der Nummer des Ereignisses, das den Patienten am meisten belastet (item `LifeEventsChecklist.MostStressfullEventNumber`), sollte eigentlich auch nur gestellt werden, wenn der Patient mehrere angekreuzt hat. Nun hab ich den Eindruck, dass man "vorher mindestens 2x JA" nicht so gut in dem Questionnaire spezifizieren kann. Daher ist die jetzige Variante ok, bis auf, dass man den Patienten nicht zwingen sollte, da irgendeine Nummer einzutragen.

Wenn ich etwas falsch gemacht habe, dann gerne commits dranhängen (auch als fixup!). Die GitHub action sollte mir ja sagen, wenn etwas nicht stimmt.